### PR TITLE
Update info of R-Ladies Lima

### DIFF
--- a/Current-Chapters.csv
+++ b/Current-Chapters.csv
@@ -109,7 +109,7 @@ Netherlands,"",Wageningen,https://www.meetup.com/rladies-wageningen/,"","","",,"
 New Zealand,"",Auckland,https://www.meetup.com/rladies-auckland/,https://twitter.com/RLadiesAKL,auckland@rladies.org,"",,"","",https://github.com/rladies/meetup-presentations_auckland,"","","Kim Fitter, Anna Martin Fergusson, Anjali Gupta",Active
 Norway,"",Oslo,https://www.meetup.com/rladies-oslo/,https://twitter.com/RLadies_Oslo,oslo@rladies.org,"",,"","",https://github.com/rladies/meetup-presentations_oslo,"","","Anne Claire Fouilloux, Athanasia Monika Mowinckel, Lene Norderhaug Drosdal, Aurora Voje, Isabelle Valette",Active
 Paraguay,"",Asunción,"","","","",,"","","","","",Flavia Sacco,Prospective
-Peru,"",Lima,https://www.meetup.com/rladies-lima/,https://twitter.com/RLadiesLima,lima@rladies.org,https://www.facebook.com/RLadiesLima,,"","",https://github.com/rladies/meetup-presentations_lima,"","","Evelyn Gutierrez, Vilma Romero, Yuriko Sosa, Ivonne Rentería, Fiorella Flores, Sherly Tarazona",Active
+Peru,"",Lima,https://www.meetup.com/rladies-lima/,https://twitter.com/RLadiesLima,lima@rladies.org,https://www.facebook.com/RLadiesLima,,"","",https://github.com/rladies/meetup-presentations_lima,"","r-ladieslima.slack.com","Ivonne Rentería, Vilma Romero, Evelyn Gutierrez, Yuriko Sosa, Sherly Tarazona",Active
 Philippines,"",Manila,"","","","",,"","","","","",Ma. Regina Justina E. Estuar,Prospective
 Poland,"",Lodz,"","","","",,"","","","","",Lidia Lipi_ska,Prospective
 Poland,"",Warsaw,http://www.meetup.com/Spotkania-Entuzjastow-R-Warsaw-R-Users-Group-Meetup/,"",warsaw@rladies.org,https://www.facebook.com/RLadiesWarsaw/,,"","","","","","Olga Mierzwa-Sulima, Natalia Potocka",Active


### PR DESCRIPTION
Add slack link of R-Ladies Lima and remove Fiorella Flores from the Organizers Team. She is currently inactive.