### PR TITLE
Update organizer list for R-Ladies San Diego.

### DIFF
--- a/Current-Chapters.csv
+++ b/Current-Chapters.csv
@@ -162,7 +162,7 @@ USA,California,Irvine,https://www.meetup.com/rladies-irvine/,https://twitter.com
 USA,California,Los Angeles,https://www.meetup.com/rladies-la/,https://twitter.com/RLadiesLA,la@rladies.org,"",,"","",https://github.com/rladies/meetup-presentations_la,"","","Katie Leap, Amanda Tilot",Active
 USA,California,Pasadena,https://www.meetup.com/R-Ladies-Pasadena/,"","","",,"","","","","","Gail Peretsman-Clement, Zhi Yang, Donna Wrublewski",Progress
 USA,California,Riverside,"","","","",,"","","","","",Teresa Bohner,Prospective
-USA,California,San Diego,https://www.meetup.com/rladies-san-diego/,https://twitter.com/RLadiesSanDiego,sandiego@rladies.org,https://www.facebook.com/groups/rladiessandiego/,,"","",https://github.com/rladies/meetup-presentations_sandiego,"","","Page Piccinini, Megan Chang",Active
+USA,California,San Diego,https://www.meetup.com/rladies-san-diego/,https://twitter.com/RLadiesSanDiego,sandiego@rladies.org,https://www.facebook.com/groups/rladiessandiego/,,"","",https://github.com/rladies/meetup-presentations_sandiego,"","","Juliana Capitanio, Viola Glenn, Elke Patton",Active
 USA,California,San Francisco,https://www.meetup.com/rladies-san-francisco/,https://twitter.com/RladiesSF,sf@rladies.org,"",,https://www.periscope.tv/RLadiesSF/,"",https://github.com/rladies/meetup-presentations_sanfrancisco,"","","Gabriela de Queiroz, Erin LeDell, Ciera Martinez",Active
 USA,California,Santa Barbara,https://www.meetup.com/rladies-santa-barbara/,https://twitter.com/RLadiesSB,santabarbara@rladies.org,"",,"","",https://github.com/rladies/meetup-presentations_santabarbara,"","","Julia Stewart Lowndes, Allison Horst, Jamie Afflerbach",Progress
 USA,California,Santa Cruz,"","","","",,"","","","","",Kate Kelsey,Prospective


### PR DESCRIPTION
Updating the list of organizers for R-Ladies San Diego to remove Page Piccinini and Megan Chang and adding Juliana Capitanio, Viola Glenn, and Elke Patton.